### PR TITLE
Add: photo comments retreival

### DIFF
--- a/admin/template/import.list_all.tpl
+++ b/admin/template/import.list_all.tpl
@@ -47,6 +47,7 @@ var flickrUserId = '{$flickrUserId}';
       <label><input type="checkbox" name="fill_views" checked="checked"> {'View counter'|translate}</label>
       <label><input type="checkbox" name="fill_level" checked="checked"> {'Privacy level'|translate}</label>
       <label><input type="checkbox" name="fill_safety" checked="checked"> {'Safety level (as keyword)'|translate}</label>
+      <label><input type="checkbox" name="fill_comments" checked="checked"> {'Comments'|translate}</label>
     </p>
 
     <p>


### PR DESCRIPTION
Simple way to keep Flickr's comments when importing.
Comments are HTML, maybe there's a way to convert them in Piwigo's format.
But it did the job.